### PR TITLE
Expose function to create S3 store from AWS config

### DIFF
--- a/s3store.go
+++ b/s3store.go
@@ -52,14 +52,8 @@ func NewS3Store(bucketName, region string) *S3Store {
 	if err != nil {
 		log.Fatal(err)
 	}
-	client := s3.NewFromConfig(cfg)
-	store := &S3Store{
-		bucket: aws.String(bucketName),
-		client: client,
-		prefix: "certmagic",
-	}
 
-	return store
+	return NewS3StoreFromConfig(bucketName, cfg)
 }
 
 func NewS3StoreWithCredentials(accessKey, secretKey, bucketName, region string) *S3Store {
@@ -70,6 +64,11 @@ func NewS3StoreWithCredentials(accessKey, secretKey, bucketName, region string) 
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	return NewS3StoreFromConfig(bucketName, cfg)
+}
+
+func NewS3StoreFromConfig(bucketName string, cfg aws.Config) *S3Store {
 	client := s3.NewFromConfig(cfg)
 	store := &S3Store{
 		bucket: aws.String(bucketName),


### PR DESCRIPTION
This allows the user to specify it's own S3 config. In our case, this is use-full as we wish to use a non-default AWS resolver.